### PR TITLE
Add Harmony theme integration

### DIFF
--- a/docs/_includes/default.njk
+++ b/docs/_includes/default.njk
@@ -36,6 +36,8 @@
     {# Shoelace #}
     <link rel="stylesheet" href="/dist/themes/light.css" />
     <link rel="stylesheet" href="/dist/themes/dark.css" />
+    <link rel="stylesheet" href="/dist/themes/harmony-light.css" />
+    <link rel="stylesheet" href="/dist/themes/harmony-dark.css" />
     <script type="module" src="/dist/shoelace-autoloader.js"></script>
 
     {# Set the initial theme and menu states here to prevent flashing #}

--- a/src/themes/harmony-dark.css
+++ b/src/themes/harmony-dark.css
@@ -1,0 +1,41 @@
+:host,
+.sl-theme-harmony-dark {
+  color-scheme: dark;
+
+  /* Harmony fonts */
+  --sl-font-sans: 'Lexend', sans-serif;
+  --sl-font-weight-light: 300;
+  --sl-font-weight-normal: 400;
+  --sl-font-weight-semibold: 500;
+  --sl-font-weight-bold: 600;
+
+  /* Brand color */
+  --sl-color-primary-50: #1a88ff;
+  --sl-color-primary-100: #1a88ff;
+  --sl-color-primary-200: #1a88ff;
+  --sl-color-primary-300: #1a88ff;
+  --sl-color-primary-400: #1a88ff;
+  --sl-color-primary-500: #1a88ff;
+  --sl-color-primary-600: #1a88ff;
+  --sl-color-primary-700: #1a88ff;
+  --sl-color-primary-800: #1a88ff;
+  --sl-color-primary-900: #1a88ff;
+  --sl-color-primary-950: #1a88ff;
+
+  /* Status colors */
+  --sl-color-success-600: #17a871;
+  --sl-color-warning-600: #ffb020;
+  --sl-color-danger-600: #d83148;
+  --sl-color-info-600: #3366ff;
+
+  /* Neutral palette */
+  --sl-color-neutral-0: #0a0e15;
+  --sl-color-neutral-50: #15171a;
+  --sl-color-neutral-100: rgba(255, 255, 255, 0.2);
+  --sl-color-neutral-900: #e9ecef;
+
+  /* Border radius */
+  --sl-border-radius-small: 2px;
+  --sl-border-radius-medium: 8px;
+  --sl-border-radius-large: 16px;
+}

--- a/src/themes/harmony-light.css
+++ b/src/themes/harmony-light.css
@@ -1,0 +1,42 @@
+:root,
+:host,
+.sl-theme-harmony-light {
+  color-scheme: light;
+
+  /* Harmony fonts */
+  --sl-font-sans: 'Lexend', sans-serif;
+  --sl-font-weight-light: 300;
+  --sl-font-weight-normal: 400;
+  --sl-font-weight-semibold: 500;
+  --sl-font-weight-bold: 600;
+
+  /* Brand color */
+  --sl-color-primary-50: #30659f;
+  --sl-color-primary-100: #30659f;
+  --sl-color-primary-200: #30659f;
+  --sl-color-primary-300: #30659f;
+  --sl-color-primary-400: #30659f;
+  --sl-color-primary-500: #30659f;
+  --sl-color-primary-600: #30659f;
+  --sl-color-primary-700: #30659f;
+  --sl-color-primary-800: #30659f;
+  --sl-color-primary-900: #30659f;
+  --sl-color-primary-950: #30659f;
+
+  /* Status colors */
+  --sl-color-success-600: #17a871;
+  --sl-color-warning-600: #ffb020;
+  --sl-color-danger-600: #d83148;
+  --sl-color-info-600: #3366ff;
+
+  /* Neutral palette */
+  --sl-color-neutral-0: #ffffff;
+  --sl-color-neutral-50: #edf0f6;
+  --sl-color-neutral-100: #bfc6d4;
+  --sl-color-neutral-900: #373f4e;
+
+  /* Border radius */
+  --sl-border-radius-small: 2px;
+  --sl-border-radius-medium: 8px;
+  --sl-border-radius-large: 16px;
+}


### PR DESCRIPTION
## Summary
- add Harmony-based light and dark themes
- include new themes in the docs layout

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: web-test-runner not found)*

------
https://chatgpt.com/codex/tasks/task_e_685049c9963483268b427c3fcf113f7e